### PR TITLE
Rely on tag for release only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ workflows:
             tags:
               only: /^v\d+\.\d+\.\d+$/
             branches:
-              ignore: /.*/
+              only: main
           requires:
             - rspec
             - rubocop


### PR DESCRIPTION
Having a default 'main' branch causes compatability issues.