### PR TITLE
fix `has_many_attached` typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ class UserType < GraphQL::Schema::Object
 
   def photos
     dataloader
-      .with(GraphQL::Sources::ActiveStorageHasOneAttached, :photos)
+      .with(GraphQL::Sources::ActiveStorageHasManyAttached, :photos)
       .load(object)
   end
 end


### PR DESCRIPTION
I really like the gem
wanted to address another typo I've found

It looks like this mean to be `ActiveStorageHasManyAttached` here