### PR TITLE
Document alternative using default loaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 `GraphQL::Sources` is a set of predefined dataloader classes build to avoid common n-plus-one issues in a GraphQL schema with Ruby. It supports loading `has_one`, `has_many`, `belongs_to`, `has_and_belongs_to_many`, `has_one_attached` and `has_many_attached` associations.
 
+_Recent versions of [graphql-ruby](https://github.com/rmosolgo/graphql-ruby) include built-in support for loading records and associations via the `dataload_record` and `dataload_association` methods. These serve as a suitable alternative to some of the methods of loading provided by this library._
+
 ## Installation
 
 Install the gem and add to the application's Gemfile by executing:


### PR DESCRIPTION
This documents the `dataload_association` and and `dataload_record` loaders built in to newer versions of GraphQL ruby. This is in support of:

https://github.com/ksylvest/graphql-sources/pull/159